### PR TITLE
Update for varnish 6.0 compatibility.

### DIFF
--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test accept vmod"
 
-server s1 {}
+server s1 {} -start
 
 varnish v1 -vcl+backend {
 	import ${vmod_accept};

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -1,6 +1,6 @@
 varnishtest "Quality quality assurance"
 
-server s1 {}
+server s1 {} -start
 
 varnish v1 -vcl+backend {
 	import ${vmod_accept};

--- a/src/vmod_accept.c
+++ b/src/vmod_accept.c
@@ -3,11 +3,19 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
+#include <string.h>
 
-/* need vcl.h before vrt.h for vmod_evet_f typedef */
-#include "vcl.h"
-#include "vrt.h"
-#include "cache/cache.h"
+#include <cache/cache.h>
+#include <vcl.h>
+
+#ifndef VRT_H_INCLUDED
+#  include <vrt.h>
+#endif
+
+#ifndef VDEF_H_INCLUDED
+#  include <vdef.h>
+#endif
+
 #include "vqueue.h"
 
 #include "vcc_accept_if.h"
@@ -28,7 +36,7 @@ struct vmod_accept_rule {
 	pthread_rwlock_t			mtx;
 };
 
-VCL_VOID __match_proto__()
+VCL_VOID
 vmod_rule__init(VRT_CTX, struct vmod_accept_rule **rulep, const char *vcl_name,
 		VCL_STRING fallback)
 {


### PR DESCRIPTION
Hi Guillaume,

Thanks for your work on vmod-accept, it's been useful on my own servers. I was in testing if I could upgrade to Varnish 6, and I'm hoping this commit helps out with porting to Varnish 6.

I ran `make distcheck` using Varnish 6 and it worked. After that, I ran `./configure && make check` two different VMs, one running 5.2 and one running 6.0, and both passed.

* Update varnish includes to reflect include order changes
* Include string.h, since varnish's headers no longer include this
* Drop __match_proto__
* varnishtest now requires the server to be started

Thanks,
-Spikes